### PR TITLE
Take a port from the env var SDX_SEFT_CONSUMER_SERVICE_PORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Remove unnecessary code
+  - Set a listen port from the env var "SEFT_SDX_CONSUMER_SERVICE_PORT", or default to 8080
 
 ### 1.0.0
   - Initial release

--- a/app/main.py
+++ b/app/main.py
@@ -249,7 +249,7 @@ def main():
 
     app = make_app()
     server = tornado.httpserver.HTTPServer(app)
-    server.bind(int(os.getenv("PORT", '8080')))
+    server.bind(int(os.getenv("SDX_SEFT_CONSUMER_SERVICE_PORT", '8080')))
     server.start(0)
 
     with open(settings.SDX_SEFT_CONSUMER_KEYS_FILE) as file:


### PR DESCRIPTION
## What? and Why?
Introduces a new env var, SDX_SEFT_CONSUMER_SERVICE_PORT and sets the listen port to this value if set, otherwise defaults to 8080.