### PR TITLE
Import publishers from sdc.rabbit module, not publisher module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+ - Import publishers from sdc.rabbit module, not sdc.rabbit.publisher
 
 ### 1.4.0 2018-02-05
  - Added support for different survey_ids

--- a/app/tests/test_publish_receive.py
+++ b/app/tests/test_publish_receive.py
@@ -18,7 +18,7 @@ from pyftpdlib.handlers import FTPHandler
 from pyftpdlib.servers import ThreadedFTPServer
 from sdc.crypto.encrypter import encrypt
 from sdc.crypto.key_store import KeyStore
-from sdc.rabbit.publisher import QueuePublisher
+from sdc.rabbit import QueuePublisher
 import tornado
 import yaml
 
@@ -107,7 +107,8 @@ class EndToEndTest(unittest.TestCase):
 
         ftp_thread = FTPThread()
         ftp_thread.start()
-        files = [f for f in listdir(TEST_FILES_PATH) if isfile(join(TEST_FILES_PATH, f)) and (f.endswith(".xls") or f.endswith(".xlsx"))]
+        files = [f for f in listdir(TEST_FILES_PATH) if isfile(
+            join(TEST_FILES_PATH, f)) and (f.endswith(".xls") or f.endswith(".xlsx"))]
         for file in files:
             with open(join(TEST_FILES_PATH, file), "rb") as fb:
                 contents = fb.read()
@@ -124,7 +125,8 @@ class EndToEndTest(unittest.TestCase):
             queue_publisher.publish_message(jwt, headers=headers)
 
             time.sleep(1)
-            self.assertTrue(filecmp.cmp(join(TEST_FILES_PATH, file), join(EndToEndTest.TARGET_PATH, file)))
+            self.assertTrue(filecmp.cmp(join(TEST_FILES_PATH, file),
+                                        join(EndToEndTest.TARGET_PATH, file)))
         time.sleep(5)
         consumer_thread.stop()
         ftp_thread.stop()


### PR DESCRIPTION
## What? and Why?
Import publishers from `sdc.rabbit` not `sdc.rabbit.publisher`. This makes the code more resilient to changes in the sdc-rabbit library module names.

## Checklist
  - [x] CHANGELOG.md updated? (if required)