### PR TITLE
Fix survey id binding logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+ - Unbind survey_id from logger at the start of processing a new SEFT
 
 ### 2.4.0 2019-06-20
  - Remove python 3.4 and 3.5 from travis builds

--- a/app/main.py
+++ b/app/main.py
@@ -121,7 +121,7 @@ class SeftConsumer:
         except TypeError:
             self.bound_logger.exception()
             raise
-            
+
         self.bound_logger = self.bound_logger.try_unbind("survey_id", "case_id", "tx_id")
 
     def _send_to_ftp(self, decoded_contents, file_path, file_name, tx_id):

--- a/app/main.py
+++ b/app/main.py
@@ -98,6 +98,7 @@ class SeftConsumer:
 
         self.bound_logger = self.bound_logger.bind(tx_id=tx_id)
         self.bound_logger = self.bound_logger.try_unbind("survey_id")
+        self.bound_logger = self.bound_logger.try_unbind("case_id")
         self.bound_logger.debug("Message Received")
         try:
             self.bound_logger.info("Decrypting message")

--- a/app/main.py
+++ b/app/main.py
@@ -97,8 +97,6 @@ class SeftConsumer:
     def process(self, encrypted_jwt, tx_id=None):
 
         self.bound_logger = self.bound_logger.bind(tx_id=tx_id)
-        self.bound_logger = self.bound_logger.try_unbind("survey_id")
-        self.bound_logger = self.bound_logger.try_unbind("case_id")
         self.bound_logger.debug("Message Received")
         try:
             self.bound_logger.info("Decrypting message")
@@ -123,6 +121,8 @@ class SeftConsumer:
         except TypeError:
             self.bound_logger.exception()
             raise
+            
+        self.bound_logger = self.bound_logger.try_unbind("survey_id", "case_id", "tx_id")
 
     def _send_to_ftp(self, decoded_contents, file_path, file_name, tx_id):
         try:

--- a/app/main.py
+++ b/app/main.py
@@ -97,6 +97,7 @@ class SeftConsumer:
     def process(self, encrypted_jwt, tx_id=None):
 
         self.bound_logger = self.bound_logger.bind(tx_id=tx_id)
+        self.bound_logger = self.bound_logger.try_unbind("survey_id")
         self.bound_logger.debug("Message Received")
         try:
             self.bound_logger.info("Decrypting message")


### PR DESCRIPTION
## What? and Why?
We had an issue where, when investigating an OPSWAT quarantine, we got confused because the same `tx_id` had 2 different `survey_id`s. This fixes that.

## Checklist
  - [x] CHANGELOG.md updated? (if required)