### PR TITLE
Add python 3.8 to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 dist: xenial
 python:
+    - "3.8"
     - "3.7"
     - "3.6"
 sudo: required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+ - Add python 3.8 to travis build
 
 ### 2.5.1 2019-10-18
  - Update amount of logging and increased amount of metadata on certain log lines


### PR DESCRIPTION
## What? and Why?
Add python 3.8 to travis builds so we can have confidence in our system when we end up upgrading the version of python we use

## Checklist
  - [x] CHANGELOG.md updated? (if required)