### PR TITLE
added transaction ID to logged errors during file extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+ - Add transaction ID to logged errors during file extraction
 
 ### 2.5.2 2019-11-08
  - Add python 3.8 to travis build

--- a/app/main.py
+++ b/app/main.py
@@ -54,7 +54,8 @@ class SeftConsumer:
                              file_name=file_name,
                              file_contents="Encoded data" if file_contents else file_contents,
                              case_id=case_id,
-                             survey_id=survey_id)
+                             survey_id=survey_id,
+                             tx_id=tx_id)
                 raise ConsumerError()
             logger.debug("Decrypted file", file_name=file_name,
                          tx_id=tx_id, case_id=case_id, survey_id=survey_id)


### PR DESCRIPTION
## What? and Why?
When a file is quarantined in SDX for extraction failure, the transaction ID is missing from the logged error. 
## Checklist
  - [x] CHANGELOG.md updated? (if required)
## Links
https://trello.com/c/9ayXCv16